### PR TITLE
src/liblink/asmv.c: changed array out[4] to out[5] which in function …

### DIFF
--- a/src/liblink/asmv.c
+++ b/src/liblink/asmv.c
@@ -298,7 +298,7 @@ spanv(Link *ctxt, LSym *cursym)
 	Prog *p, *q;
 	Optab *o;
 	int m, bflag, i, j;
-	int32 out[4], c, otxt;
+	int32 out[5], c, otxt;
 	uchar *bp, *cast;
 
 	p = cursym->text;


### PR DESCRIPTION
There are 5 int32, should declare int32[5].